### PR TITLE
Import logsumexp from scipy.special

### DIFF
--- a/Python-module/SpatialDE/base.py
+++ b/Python-module/SpatialDE/base.py
@@ -10,7 +10,7 @@ from scipy import optimize
 from scipy import linalg
 from scipy import stats
 from scipy.misc import derivative
-from scipy.misc import logsumexp
+from scipy.special import logsumexp
 
 with warnings.catch_warnings():
     warnings.simplefilter('ignore')


### PR DESCRIPTION
Importing many things from scipy.misc has been [deprecated for a while](https://docs.scipy.org/doc/scipy-1.2.0/reference/misc.html) and in scipy 1.3 it’s [all gone](https://docs.scipy.org/doc/scipy-1.3.0/reference/misc.html)