### PR TITLE
fix bug caused by syntax error

### DIFF
--- a/Python-module/SpatialDE/base.py
+++ b/Python-module/SpatialDE/base.py
@@ -475,7 +475,7 @@ def model_search(X, exp_tab, DE_mll_results, kernel_space=None):
 
     # Retain information from significance testing in the new table
     transfer_columns = ['pval', 'qval', 'max_ll_null']
-    ms_results = ms_results.drop(transfer_columns, 1) \
+    ms_results = ms_results.drop(transfer_columns, axis=1) \
         .merge(DE_mll_results[transfer_columns + ['g']], on='g')
 
     return ms_results


### PR DESCRIPTION
fix bug : caused by syntax error of dataframe.drop
[TypeError: DataFrame.drop() takes from 1 to 2 positional arguments but 3 were given](https://stackoverflow.com/questions/76411055/typeerror-dataframe-drop-takes-from-1-to-2-positional-arguments-but-3-were-gi)